### PR TITLE
Fix tx_result for history transactions

### DIFF
--- a/app/jobs/history/ledger_importer_job.rb
+++ b/app/jobs/history/ledger_importer_job.rb
@@ -90,7 +90,7 @@ class History::LedgerImporterJob < ApplicationJob
       fee_paid:               as_amount(sctx.fee_paid),
       operation_count:        sctx.operations.size,
       tx_envelope:            sctx.txbody,
-      tx_result:              sctx.txresult,
+      tx_result:              sctx.txresult_without_pair,
       tx_meta:                sctx.txmeta,
       transaction_status_id:  -1,
     })

--- a/app/models/stellar_core/transaction.rb
+++ b/app/models/stellar_core/transaction.rb
@@ -108,4 +108,8 @@ class StellarCore::Transaction < StellarCore::Base
   memoize def operations_with_results
     operations.zip(operation_results)
   end
+
+  def txresult_without_pair
+    Stellar::Convert.to_base64 result.to_xdr
+  end
 end


### PR DESCRIPTION
This commit changes the contents of the history_transactions.tx_result
column from an encoded TransactionResultPair object to an encoded
TransactionResult object.