### PR TITLE
Importer improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'dotenv-rails', github: "bkeepers/dotenv"
 group :test, :development do
   gem 'rspec-rails'
   gem 'pry-rails'
-  gem 'shoulda-matchers'
+  gem 'shoulda-matchers', "= 2.8.0"
   gem 'guard'
   gem 'guard-rspec'
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/bkeepers/dotenv.git
-  revision: e13bf8a877e2237b1c91c66c775f88bbcaafe314
+  revision: 8006812f122efe09319e691fda4b1dd4a7ff6889
   specs:
     dotenv (2.0.2)
     dotenv-rails (2.0.2)
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: git://github.com/stellar/stellar_core_commander.git
-  revision: 3cf3a37cb99286ed4d6e39cc78b03710201aa0a5
+  revision: 65001ef09effe36896956eb73c348c8b236678df
   specs:
     stellar_core_commander (0.0.12)
       activesupport (>= 4.0.0)
@@ -113,7 +113,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hitimes (1.2.3)
     i18n (0.7.0)
-    jbuilder (2.3.1)
+    jbuilder (2.3.2)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
     json (1.8.3)
@@ -151,13 +151,13 @@ GEM
     oat (0.4.6)
       activesupport
     pg (0.18.3)
-    pry (0.10.1)
+    pry (0.10.2)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    puma (2.13.4)
+    puma (2.14.0)
     rack (1.6.4)
     rack-attack (4.3.0)
       rack
@@ -223,7 +223,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    sentry-raven (0.15.0)
+    sentry-raven (0.15.2)
       faraday (>= 0.7.6)
     sequel (4.21.0)
     shellany (0.0.1)
@@ -235,20 +235,20 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    sprockets (3.3.4)
-      rack (~> 1.0)
+    sprockets (3.3.5)
+      rack (> 1, < 3)
     sprockets-rails (2.3.3)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.10)
-    stellar-base (0.6.1)
+    stellar-base (0.7.0)
       activesupport (~> 4)
       base32
       digest-crc
       rbnacl
       rbnacl-libsodium (~> 1.0.3)
-      xdr (>= 0.0.4)
+      xdr (~> 1.0.0)
     sucker_punch (1.5.1)
       celluloid (= 0.16.0)
     thor (0.19.1)
@@ -262,7 +262,7 @@ GEM
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    xdr (0.1.0)
+    xdr (1.0.0)
       activemodel (~> 4)
       activesupport (~> 4)
       backports (~> 3.6)
@@ -301,7 +301,7 @@ DEPENDENCIES
   rspec-rails
   sdoc (~> 0.4.0)
   sentry-raven
-  shoulda-matchers
+  shoulda-matchers (= 2.8.0)
   simplecov
   sqlite3
   stellar-base

--- a/app/jobs/history/ledger_importer_job.rb
+++ b/app/jobs/history/ledger_importer_job.rb
@@ -81,18 +81,22 @@ class History::LedgerImporterJob < ApplicationJob
 
   def import_history_transaction(sctx)
     htx = History::Transaction.create!({
-      transaction_hash:       sctx.txid,
-      ledger_sequence:        sctx.ledgerseq,
-      application_order:      sctx.txindex,
-      account:                sctx.submitting_address,
-      account_sequence:       sctx.submitting_sequence,
-      max_fee:                as_amount(sctx.fee_paid),
-      fee_paid:               as_amount(sctx.fee_paid),
-      operation_count:        sctx.operations.size,
-      tx_envelope:            sctx.txbody,
-      tx_result:              sctx.txresult_without_pair,
-      tx_meta:                sctx.txmeta,
-      tx_fee_meta:            sctx.fee_meta.xdr,
+      transaction_hash:   sctx.txid,
+      ledger_sequence:    sctx.ledgerseq,
+      application_order:  sctx.txindex,
+      account:            sctx.submitting_address,
+      account_sequence:   sctx.submitting_sequence,
+      max_fee:            as_amount(sctx.fee_paid),
+      fee_paid:           as_amount(sctx.fee_paid),
+      operation_count:    sctx.operations.size,
+      tx_envelope:        sctx.txbody,
+      tx_result:          sctx.txresult_without_pair,
+      tx_meta:            sctx.txmeta,
+      tx_fee_meta:        sctx.fee_meta.xdr,
+      signatures:         sctx.signatures,
+      time_bounds:        sctx.time_bounds,
+      memo_type:          sctx.memo_type,
+      memo:               sctx.memo,
     })
 
     sctx.participant_addresses.each do |addr|
@@ -132,13 +136,15 @@ class History::LedgerImporterJob < ApplicationJob
       op, result = *op_and_r
 
       source_account = op.source_account || sctx.source_account
-      participant_addresses = [Stellar::Convert.pk_to_address(source_account)]
+      source_address = Stellar::Convert.pk_to_address(source_account) 
+      participant_addresses = [source_address]
 
       hop = History::Operation.new({
-        transaction_id:    htx.id,
-        application_order: application_order,
-        type:              op.body.type.value,
-        details:           {},
+        transaction_id:     htx.id,
+        application_order:  application_order,
+        type:               op.body.type.value,
+        source_account:     source_address,
+        details:            {},
       })
 
 

--- a/app/models/stellar_core/transaction.rb
+++ b/app/models/stellar_core/transaction.rb
@@ -118,4 +118,41 @@ class StellarCore::Transaction < StellarCore::Base
   def txresult_without_pair
     Stellar::Convert.to_base64 result.to_xdr
   end
+
+  def signatures
+    envelope.signatures.map{|s| Stellar::Convert.to_base64(s.signature)}
+  end
+
+  def memo_type
+    type = envelope.tx.memo.type
+    case type
+    when Stellar::MemoType.memo_none ;    "none"
+    when Stellar::MemoType.memo_text ;    "text"
+    when Stellar::MemoType.memo_id ;      "id"
+    when Stellar::MemoType.memo_hash ;    "hash"
+    when Stellar::MemoType.memo_return ;  "return"
+    else
+      raise "Unknown memo type: #{type}"
+    end
+  end
+
+  def memo
+    case memo_type
+    when "none" ;    nil
+    when "text" ;    envelope.tx.memo.text!
+    when "id" ;      envelope.tx.memo.id!.to_s
+    when "hash" ;    Stellar::Convert.to_base64(envelope.tx.memo.hash!)
+    when "return" ;  Stellar::Convert.to_base64(envelope.tx.memo.ret_hash!)
+    else
+      raise "Unknown memo type: #{type}"
+    end
+  end
+
+  def time_bounds
+    tb = envelope.tx.time_bounds
+    return nil if tb.blank?
+
+    tb.min_time..tb.max_time
+  end
+
 end

--- a/db/migrate/20151006205250_add_more_fields.rb
+++ b/db/migrate/20151006205250_add_more_fields.rb
@@ -1,0 +1,14 @@
+class AddMoreFields < ActiveRecord::Migration
+  def change
+    change_table :history_operations do |t|
+      t.string :source_account, limit: 64, null: false, default: ""
+    end 
+
+    change_table :history_transactions do |t|
+      t.string :signatures, limit: 96, array: true, null: false, default: []
+      t.string :memo_type, null: false, default: "none"
+      t.string :memo
+      t.int8range :time_bounds
+    end 
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -123,7 +123,8 @@ CREATE TABLE history_operations (
     transaction_id bigint NOT NULL,
     application_order integer NOT NULL,
     type integer NOT NULL,
-    details jsonb
+    details jsonb,
+    source_account character varying(64) DEFAULT ''::character varying NOT NULL
 );
 
 
@@ -208,7 +209,11 @@ CREATE TABLE history_transactions (
     tx_envelope text NOT NULL,
     tx_result text NOT NULL,
     tx_meta text NOT NULL,
-    tx_fee_meta text NOT NULL
+    tx_fee_meta text NOT NULL,
+    signatures character varying(96)[] DEFAULT '{}'::character varying[] NOT NULL,
+    memo_type character varying DEFAULT 'none'::character varying NOT NULL,
+    memo character varying,
+    time_bounds int8range
 );
 
 
@@ -474,4 +479,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150825223417');
 INSERT INTO schema_migrations (version) VALUES ('20150902224148');
 
 INSERT INTO schema_migrations (version) VALUES ('20150929205440');
+
+INSERT INTO schema_migrations (version) VALUES ('20151006205250');
 


### PR DESCRIPTION
Big batch of random history importer improvements:

- Import `path` for path payment operations
- Import `signatures` for transactions
- Import `memo_type` and `memo` for transactions
- Import `time_bounds` for transactions
- Import `source_account` for operations
- Rename `send_*` attributes to `source_*` for consistency
- Import `source_max` for path payments
- Fix "master account is missing from /accounts" bug