### PR TITLE
Remove nullability from new ledger columns

### DIFF
--- a/db/migrate/20151020225251_lockdown_ledger.rb
+++ b/db/migrate/20151020225251_lockdown_ledger.rb
@@ -1,0 +1,9 @@
+class LockdownLedger < ActiveRecord::Migration
+  def change
+    change_column_null :history_ledgers, :total_coins, false
+    change_column_null :history_ledgers, :fee_pool, false
+    change_column_null :history_ledgers, :base_fee, false
+    change_column_null :history_ledgers, :base_reserve, false
+    change_column_null :history_ledgers, :max_tx_set_size, false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -81,11 +81,11 @@ CREATE TABLE history_ledgers (
     updated_at timestamp without time zone,
     id bigint,
     importer_version integer DEFAULT 1 NOT NULL,
-    total_coins bigint,
-    fee_pool bigint,
-    base_fee integer,
-    base_reserve integer,
-    max_tx_set_size integer
+    total_coins bigint NOT NULL,
+    fee_pool bigint NOT NULL,
+    base_fee integer NOT NULL,
+    base_reserve integer NOT NULL,
+    max_tx_set_size integer NOT NULL
 );
 
 
@@ -497,4 +497,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151006205250');
 INSERT INTO schema_migrations (version) VALUES ('20151011210811');
 
 INSERT INTO schema_migrations (version) VALUES ('20151020211921');
+
+INSERT INTO schema_migrations (version) VALUES ('20151020225251');
 

--- a/spec/factories/history_ledgers.rb
+++ b/spec/factories/history_ledgers.rb
@@ -7,6 +7,11 @@ FactoryGirl.define do
     transaction_count 0
     operation_count   0
     closed_at         { Time.now }
+    total_coins       0
+    fee_pool          0
+    base_fee          0
+    base_reserve      0
+    max_tx_set_size   0
 
     # TODO: add ability to specify transactions
     # and random transaction defaults


### PR DESCRIPTION
This PR removes the nullability of the ledger columns added in #66 

After history has been updated to include all old data, this PR can be merged and the migration run.