### PR TITLE
Extract `ParticipantFinder`, fix missing participants issue

### DIFF
--- a/app/models/stellar_core/participant_finder.rb
+++ b/app/models/stellar_core/participant_finder.rb
@@ -1,0 +1,83 @@
+module StellarCore
+  module ParticipantFinder
+
+    def from_tx(tx)
+      [
+        tx.source_account,
+        from_meta(tx.meta, tx.fee_meta),
+        from_operations(tx.operations),
+      ].flatten.uniq
+    end
+
+    def from_meta(meta, fee_meta)
+      results = []
+      all_changes = meta.operations!.flat_map(&:changes)
+      all_changes += fee_meta.changes
+      all_changes.each do |change|
+        data = case change.type
+               when Stellar::LedgerEntryChangeType.ledger_entry_created
+                 change.created!.data
+               when Stellar::LedgerEntryChangeType.ledger_entry_updated
+                 change.updated!.data
+               when Stellar::LedgerEntryChangeType.ledger_entry_removed
+                 change.removed!
+               when Stellar::LedgerEntryChangeType.ledger_entry_state
+                 next # "state" entries are not needed to calculate participants
+               else
+                 raise "Unknown ledger entry change type: #{change.type}"
+               end
+
+
+        next unless data.type == Stellar::LedgerEntryType.account
+
+        results << data.account!.account_id
+      end
+
+      results.uniq
+    end
+
+    def from_operations(ops)
+      ops.flat_map{|op| from_operation(op)}
+    end
+
+    # from_operation returns the account ids for the _direct_ participants of
+    # `op`.  This list is not exhaustive;  For example, a participant whose
+    # offer is taken to fulfill a path payment will not be returned by this
+    # method.
+    def from_operation(op)
+      results = []
+      if op.source_account.present?
+        results << op.source_account
+      end
+
+      case op.body.type
+      when Stellar::OperationType.create_account;
+        results << op.body.value.destination
+      when Stellar::OperationType.payment;
+        results << op.body.value.destination
+      when Stellar::OperationType.path_payment;
+        results << op.body.value.destination
+      when Stellar::OperationType.manage_offer;
+        # the only direct participant is the source_account
+      when Stellar::OperationType.create_passive_offer;
+        # the only direct participant is the source_account
+      when Stellar::OperationType.set_options;
+        # the only direct participant is the source_account
+      when Stellar::OperationType.change_trust;
+        # the only direct participant is the source_account
+      when Stellar::OperationType.allow_trust;
+        results << op.body.value.trustor
+      when Stellar::OperationType.account_merge;
+        op.body.value
+      when Stellar::OperationType.inflation;
+        # the only direct participant is the source_account
+      else
+        raise ArgumentError, "Unknown operation type: #{op.body.type}"
+      end
+
+      return results
+    end
+
+    extend self
+  end
+end

--- a/spec/fixtures/scenarios/send_to_issuer-core.sql
+++ b/spec/fixtures/scenarios/send_to_issuer-core.sql
@@ -1,0 +1,572 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+SET search_path = public, pg_catalog;
+
+DROP INDEX public.signersaccount;
+DROP INDEX public.sellingissuerindex;
+DROP INDEX public.scpenvsbyseq;
+DROP INDEX public.priceindex;
+DROP INDEX public.ledgersbyseq;
+DROP INDEX public.histfeebyseq;
+DROP INDEX public.histbyseq;
+DROP INDEX public.buyingissuerindex;
+DROP INDEX public.accountbalances;
+ALTER TABLE ONLY public.txhistory DROP CONSTRAINT txhistory_pkey;
+ALTER TABLE ONLY public.txfeehistory DROP CONSTRAINT txfeehistory_pkey;
+ALTER TABLE ONLY public.trustlines DROP CONSTRAINT trustlines_pkey;
+ALTER TABLE ONLY public.storestate DROP CONSTRAINT storestate_pkey;
+ALTER TABLE ONLY public.signers DROP CONSTRAINT signers_pkey;
+ALTER TABLE ONLY public.scpquorums DROP CONSTRAINT scpquorums_pkey;
+ALTER TABLE ONLY public.pubsub DROP CONSTRAINT pubsub_pkey;
+ALTER TABLE ONLY public.publishqueue DROP CONSTRAINT publishqueue_pkey;
+ALTER TABLE ONLY public.peers DROP CONSTRAINT peers_pkey;
+ALTER TABLE ONLY public.offers DROP CONSTRAINT offers_pkey;
+ALTER TABLE ONLY public.ledgerheaders DROP CONSTRAINT ledgerheaders_pkey;
+ALTER TABLE ONLY public.ledgerheaders DROP CONSTRAINT ledgerheaders_ledgerseq_key;
+ALTER TABLE ONLY public.accounts DROP CONSTRAINT accounts_pkey;
+DROP TABLE public.txhistory;
+DROP TABLE public.txfeehistory;
+DROP TABLE public.trustlines;
+DROP TABLE public.storestate;
+DROP TABLE public.signers;
+DROP TABLE public.scpquorums;
+DROP TABLE public.scphistory;
+DROP TABLE public.pubsub;
+DROP TABLE public.publishqueue;
+DROP TABLE public.peers;
+DROP TABLE public.offers;
+DROP TABLE public.ledgerheaders;
+DROP TABLE public.accounts;
+DROP EXTENSION plpgsql;
+DROP SCHEMA public;
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA public;
+
+
+--
+-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON SCHEMA public IS 'standard public schema';
+
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+SET search_path = public, pg_catalog;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: accounts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE accounts (
+    accountid character varying(56) NOT NULL,
+    balance bigint NOT NULL,
+    seqnum bigint NOT NULL,
+    numsubentries integer NOT NULL,
+    inflationdest character varying(56),
+    homedomain character varying(32) NOT NULL,
+    thresholds text NOT NULL,
+    flags integer NOT NULL,
+    lastmodified integer NOT NULL,
+    CONSTRAINT accounts_balance_check CHECK ((balance >= 0)),
+    CONSTRAINT accounts_numsubentries_check CHECK ((numsubentries >= 0))
+);
+
+
+--
+-- Name: ledgerheaders; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE ledgerheaders (
+    ledgerhash character(64) NOT NULL,
+    prevhash character(64) NOT NULL,
+    bucketlisthash character(64) NOT NULL,
+    ledgerseq integer,
+    closetime bigint NOT NULL,
+    data text NOT NULL,
+    CONSTRAINT ledgerheaders_closetime_check CHECK ((closetime >= 0)),
+    CONSTRAINT ledgerheaders_ledgerseq_check CHECK ((ledgerseq >= 0))
+);
+
+
+--
+-- Name: offers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE offers (
+    sellerid character varying(56) NOT NULL,
+    offerid bigint NOT NULL,
+    sellingassettype integer NOT NULL,
+    sellingassetcode character varying(12),
+    sellingissuer character varying(56),
+    buyingassettype integer NOT NULL,
+    buyingassetcode character varying(12),
+    buyingissuer character varying(56),
+    amount bigint NOT NULL,
+    pricen integer NOT NULL,
+    priced integer NOT NULL,
+    price double precision NOT NULL,
+    flags integer NOT NULL,
+    lastmodified integer NOT NULL,
+    CONSTRAINT offers_amount_check CHECK ((amount >= 0)),
+    CONSTRAINT offers_offerid_check CHECK ((offerid >= 0))
+);
+
+
+--
+-- Name: peers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE peers (
+    ip character varying(15) NOT NULL,
+    port integer DEFAULT 0 NOT NULL,
+    nextattempt timestamp without time zone NOT NULL,
+    numfailures integer DEFAULT 0 NOT NULL,
+    CONSTRAINT peers_numfailures_check CHECK ((numfailures >= 0)),
+    CONSTRAINT peers_port_check CHECK (((port > 0) AND (port <= 65535)))
+);
+
+
+--
+-- Name: publishqueue; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE publishqueue (
+    ledger integer NOT NULL,
+    state text
+);
+
+
+--
+-- Name: pubsub; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE pubsub (
+    resid character(32) NOT NULL,
+    lastread integer
+);
+
+
+--
+-- Name: scphistory; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE scphistory (
+    nodeid character(56) NOT NULL,
+    ledgerseq integer NOT NULL,
+    envelope text NOT NULL,
+    CONSTRAINT scphistory_ledgerseq_check CHECK ((ledgerseq >= 0))
+);
+
+
+--
+-- Name: scpquorums; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE scpquorums (
+    qsethash character(64) NOT NULL,
+    lastledgerseq integer NOT NULL,
+    qset text NOT NULL,
+    CONSTRAINT scpquorums_lastledgerseq_check CHECK ((lastledgerseq >= 0))
+);
+
+
+--
+-- Name: signers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE signers (
+    accountid character varying(56) NOT NULL,
+    publickey character varying(56) NOT NULL,
+    weight integer NOT NULL
+);
+
+
+--
+-- Name: storestate; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE storestate (
+    statename character(32) NOT NULL,
+    state text
+);
+
+
+--
+-- Name: trustlines; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE trustlines (
+    accountid character varying(56) NOT NULL,
+    assettype integer NOT NULL,
+    issuer character varying(56) NOT NULL,
+    assetcode character varying(12) NOT NULL,
+    tlimit bigint NOT NULL,
+    balance bigint NOT NULL,
+    flags integer NOT NULL,
+    lastmodified integer NOT NULL,
+    CONSTRAINT trustlines_balance_check CHECK ((balance >= 0)),
+    CONSTRAINT trustlines_tlimit_check CHECK ((tlimit > 0))
+);
+
+
+--
+-- Name: txfeehistory; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE txfeehistory (
+    txid character(64) NOT NULL,
+    ledgerseq integer NOT NULL,
+    txindex integer NOT NULL,
+    txchanges text NOT NULL,
+    CONSTRAINT txfeehistory_ledgerseq_check CHECK ((ledgerseq >= 0))
+);
+
+
+--
+-- Name: txhistory; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE txhistory (
+    txid character(64) NOT NULL,
+    ledgerseq integer NOT NULL,
+    txindex integer NOT NULL,
+    txbody text NOT NULL,
+    txresult text NOT NULL,
+    txmeta text NOT NULL,
+    CONSTRAINT txhistory_ledgerseq_check CHECK ((ledgerseq >= 0))
+);
+
+
+--
+-- Data for Name: accounts; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified) FROM stdin;
+GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H	999999997999999800	2	0	\N		AQAAAA==	0	2
+GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4	999999900	8589934593	0	\N		AQAAAA==	0	4
+GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU	999999800	8589934594	1	\N		AQAAAA==	0	5
+\.
+
+
+--
+-- Data for Name: ledgerheaders; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY ledgerheaders (ledgerhash, prevhash, bucketlisthash, ledgerseq, closetime, data) FROM stdin;
+63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99	0000000000000000000000000000000000000000000000000000000000000000	572a2e32ff248a07b0e70fd1f6d318c1facd20b6cc08c33d5775259868125a16	1	0	AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXKi4y/ySKB7DnD9H20xjB+s0gtswIwz1XdSWYaBJaFgAAAAEN4Lazp2QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAX14QAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+d12eb85f9bdd048febc51e631a9c452c14eac4a880c13ed8be80ba928f8656b8	63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99	aa8b1ab49f50fced171d1a71ecacb11bde53924c80728ca72b3801e240b93a6d	2	1450129135	AAAAAWPZj1Nu5o0bJ7W4nyOvUxG3Vpok+vFAOtC1K2M7B76ZUJe9O5kAzNzu/6p0ZJoZ88h0TDub3uYslZJ7cSsRWgAAAAAAVm827wAAAAIAAAAIAAAAAQAAAAEAAAAIAAAAAwAAADIAAAAAAnQIKiwQ7y1yg69ER0rE+8ttWxjdS9dphrI7bdn6YS6qixq0n1D87RcdGnHsrLEb3lOSTIByjKcrOAHiQLk6bQAAAAIN4Lazp2QAAAAAAAAAAADIAAAAAAAAAAAAAAAAAAAAZAX14QAAAAAyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+807e56efd45afe7cf77875c534185c3f0409151c8b7455653c78f28c86fabe78	d12eb85f9bdd048febc51e631a9c452c14eac4a880c13ed8be80ba928f8656b8	ad49fe6f2ee12922d2bf234812c577955d35db8aaada9f1ce8a1b2646318d683	3	1450129136	AAAAAdEuuF+b3QSP68UeYxqcRSwU6sSogME+2L6AupKPhla4WC3N4sQ5JsavsH6dF8CP92mz4PDA23NmpAYaGECF3r4AAAAAVm828AAAAAAAAAAALLKPbMojH+RR+TSBDKGB/tufH2mL12ccCHr1Jn27yPCtSf5vLuEpItK/I0gSxXeVXTXbiqranxzoobJkYxjWgwAAAAMN4Lazp2QAAAAAAAAAAAEsAAAAAAAAAAAAAAAAAAAAZAX14QAAAAAyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+cc10b6a779f2ba2008512d31699c8391e83a231289c1bddb84e8400feb2e17ed	807e56efd45afe7cf77875c534185c3f0409151c8b7455653c78f28c86fabe78	a3e5e8770cde6cfc6ba8ceef28ba14d884ac8c7d63f455d60a21fb74efb974d5	4	1450129137	AAAAAYB+Vu/UWv5893h1xTQYXD8ECRUci3RVZTx48oyG+r54ywtLDNH3qIKE/EVvdbs8q+K7SB2aY37tDJCm6ul0738AAAAAVm828QAAAAAAAAAANvoQ5f0h4XOu2zzdNp+2aYFizWM/TiKsCFrgq+HrV6Kj5eh3DN5s/Guozu8ouhTYhKyMfWP0VdYKIft077l01QAAAAQN4Lazp2QAAAAAAAAAAAGQAAAAAAAAAAAAAAAAAAAAZAX14QAAAAAyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+110d867ec95a9aff1ddc50fb9687450a754e46f9912d1df49c5fba901568d6da	cc10b6a779f2ba2008512d31699c8391e83a231289c1bddb84e8400feb2e17ed	651600da0914d1f2730338b4cfaf1bfb1af08eef5a160918d889ec40a2bcfde3	5	1450129138	AAAAAcwQtqd58rogCFEtMWmcg5HoOiMSicG924ToQA/rLhft7oaA11EUvonNZRTm9PEvc3xoJCigdmiaWEHY7Pfxd/AAAAAAVm828gAAAAAAAAAAqwSxrFb8etq4gSdxOi9F1KjbMMbBhDJdKXyKRqyFTJtlFgDaCRTR8nMDOLTPrxv7GvCO71oWCRjYiexAorz94wAAAAUN4Lazp2QAAAAAAAAAAAH0AAAAAAAAAAAAAAAAAAAAZAX14QAAAAAyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+\.
+
+
+--
+-- Data for Name: offers; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY offers (sellerid, offerid, sellingassettype, sellingassetcode, sellingissuer, buyingassettype, buyingassetcode, buyingissuer, amount, pricen, priced, price, flags, lastmodified) FROM stdin;
+\.
+
+
+--
+-- Data for Name: peers; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY peers (ip, port, nextattempt, numfailures) FROM stdin;
+\.
+
+
+--
+-- Data for Name: publishqueue; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY publishqueue (ledger, state) FROM stdin;
+\.
+
+
+--
+-- Data for Name: pubsub; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY pubsub (resid, lastread) FROM stdin;
+\.
+
+
+--
+-- Data for Name: scphistory; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY scphistory (nodeid, ledgerseq, envelope) FROM stdin;
+GC4G2ZN46MBR3BPJPBUAR7TN675NVI3FTTBZTHQX2M72CAV477VHIKJY	2	AAAAALhtZbzzAx2F6XhoCP5t9/rao2Wcw5meF9M/oQK8/+p0AAAAAAAAAAIAAAACAAAAAQAAAEhQl707mQDM3O7/qnRkmhnzyHRMO5ve5iyVkntxKxFaAAAAAABWbzbvAAAAAgAAAAgAAAABAAAAAQAAAAgAAAADAAAAMgAAAAAAAAABnRwAm426XvfKSldERLi5YzlyCwFCV+/KD+45+Sur4YAAAABAKX0faEYbbybXSecJ4zIJCBDfBSongHV4bf6CnsFewTTFcgm7V2t1MJNaJzdqocz/9gyKlA9iXhbMppL1YtTmBg==
+GC4G2ZN46MBR3BPJPBUAR7TN675NVI3FTTBZTHQX2M72CAV477VHIKJY	3	AAAAALhtZbzzAx2F6XhoCP5t9/rao2Wcw5meF9M/oQK8/+p0AAAAAAAAAAMAAAACAAAAAQAAADBYLc3ixDkmxq+wfp0XwI/3abPg8MDbc2akBhoYQIXevgAAAABWbzbwAAAAAAAAAAAAAAABnRwAm426XvfKSldERLi5YzlyCwFCV+/KD+45+Sur4YAAAABA888TQMVgA1cDMicO3lQD60nr4rw4XqTQVpfhNlx0h2o0baPaWSr4MPmidXo1CiS3eVahe3DhGIBEX4VdMPChCA==
+GC4G2ZN46MBR3BPJPBUAR7TN675NVI3FTTBZTHQX2M72CAV477VHIKJY	4	AAAAALhtZbzzAx2F6XhoCP5t9/rao2Wcw5meF9M/oQK8/+p0AAAAAAAAAAQAAAACAAAAAQAAADDLC0sM0feogoT8RW91uzyr4rtIHZpjfu0MkKbq6XTvfwAAAABWbzbxAAAAAAAAAAAAAAABnRwAm426XvfKSldERLi5YzlyCwFCV+/KD+45+Sur4YAAAABAdnLGn57cXinPiTAHG0S96iwxDtyA8MbTHMluBVdiO/7Ds7f2ALZMMg2Pjs/7KJzNFScrXvc0kwcyaydZFt0TBg==
+GC4G2ZN46MBR3BPJPBUAR7TN675NVI3FTTBZTHQX2M72CAV477VHIKJY	5	AAAAALhtZbzzAx2F6XhoCP5t9/rao2Wcw5meF9M/oQK8/+p0AAAAAAAAAAUAAAACAAAAAQAAADDuhoDXURS+ic1lFOb08S9zfGgkKKB2aJpYQdjs9/F38AAAAABWbzbyAAAAAAAAAAAAAAABnRwAm426XvfKSldERLi5YzlyCwFCV+/KD+45+Sur4YAAAABAPKGgL0Er2AOtwxKRYaJbBS+f0JanPgipKEIMtdk8yPpVuK5eZvIjifywtFa/Bq6p9eNzLzFev2IjvItpf3JfBQ==
+\.
+
+
+--
+-- Data for Name: scpquorums; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY scpquorums (qsethash, lastledgerseq, qset) FROM stdin;
+9d1c009b8dba5ef7ca4a574444b8b96339720b014257efca0fee39f92babe180	5	AAAAAQAAAAEAAAAAuG1lvPMDHYXpeGgI/m33+tqjZZzDmZ4X0z+hArz/6nQAAAAA
+\.
+
+
+--
+-- Data for Name: signers; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY signers (accountid, publickey, weight) FROM stdin;
+\.
+
+
+--
+-- Data for Name: storestate; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY storestate (statename, state) FROM stdin;
+databaseschema                  	2
+forcescponnextlaunch            	false
+lastclosedledger                	110d867ec95a9aff1ddc50fb9687450a754e46f9912d1df49c5fba901568d6da
+historyarchivestate             	{\n    "version": 1,\n    "server": "v0.3.3-7-geed8964",\n    "currentLedger": 5,\n    "currentBuckets": [\n        {\n            "curr": "216adf8a80d1f692bf7016796b687efe0f551079f5c27cee55cde897143d62c5",\n            "next": {\n                "state": 0\n            },\n            "snap": "02870372fb6117ddff082a472980c4cc3c9575be56edc7c87991ab815debf0ae"\n        },\n        {\n            "curr": "ef31a20a398ee73ce22275ea8177786bac54656f33dcc4f3fec60d55ddf163d9",\n            "next": {\n                "state": 1,\n                "output": "02870372fb6117ddff082a472980c4cc3c9575be56edc7c87991ab815debf0ae"\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        },\n        {\n            "curr": "0000000000000000000000000000000000000000000000000000000000000000",\n            "next": {\n                "state": 0\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        },\n        {\n            "curr": "0000000000000000000000000000000000000000000000000000000000000000",\n            "next": {\n                "state": 0\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        },\n        {\n            "curr": "0000000000000000000000000000000000000000000000000000000000000000",\n            "next": {\n                "state": 0\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        },\n        {\n            "curr": "0000000000000000000000000000000000000000000000000000000000000000",\n            "next": {\n                "state": 0\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        },\n        {\n            "curr": "0000000000000000000000000000000000000000000000000000000000000000",\n            "next": {\n                "state": 0\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        },\n        {\n            "curr": "0000000000000000000000000000000000000000000000000000000000000000",\n            "next": {\n                "state": 0\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        },\n        {\n            "curr": "0000000000000000000000000000000000000000000000000000000000000000",\n            "next": {\n                "state": 0\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        },\n        {\n            "curr": "0000000000000000000000000000000000000000000000000000000000000000",\n            "next": {\n                "state": 0\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        },\n        {\n            "curr": "0000000000000000000000000000000000000000000000000000000000000000",\n            "next": {\n                "state": 0\n            },\n            "snap": "0000000000000000000000000000000000000000000000000000000000000000"\n        }\n    ]\n}
+lastscpdata                     	AAAAAgAAAAC4bWW88wMdhel4aAj+bff62qNlnMOZnhfTP6ECvP/qdAAAAAAAAAAFAAAAA50cAJuNul73ykpXRES4uWM5cgsBQlfvyg/uOfkrq+GAAAAAAQAAADDuhoDXURS+ic1lFOb08S9zfGgkKKB2aJpYQdjs9/F38AAAAABWbzbyAAAAAAAAAAAAAAABAAAAMO6GgNdRFL6JzWUU5vTxL3N8aCQooHZomlhB2Oz38XfwAAAAAFZvNvIAAAAAAAAAAAAAAEAIWSiywJL8ayZdaRfKfWmox2nV5EZSZkQdUDFzM18Z7tcx9aXfaLzCjb4k3dl9/hYPrn/SnQBiGjxS89TeInsGAAAAALhtZbzzAx2F6XhoCP5t9/rao2Wcw5meF9M/oQK8/+p0AAAAAAAAAAUAAAACAAAAAQAAADDuhoDXURS+ic1lFOb08S9zfGgkKKB2aJpYQdjs9/F38AAAAABWbzbyAAAAAAAAAAAAAAABnRwAm426XvfKSldERLi5YzlyCwFCV+/KD+45+Sur4YAAAABAPKGgL0Er2AOtwxKRYaJbBS+f0JanPgipKEIMtdk8yPpVuK5eZvIjifywtFa/Bq6p9eNzLzFev2IjvItpf3JfBQAAAAHMELanefK6IAhRLTFpnIOR6DojEonBvduE6EAP6y4X7QAAAAEAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAABkAAAAAgAAAAIAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAC1uBdHoTugMvQtD7BhIL3Ne9dVPfGI+Ji5JvUO+ZAt7wAAAAFVU0QAAAAAALW4F0ehO6Ay9C0PsGEgvc1711U98Yj4mLkm9Q75kC3vAAAAF0h26AAAAAAAAAAAAa7kvkwAAABAnt8vooy2MPp6VSDo4R3Si++Fuadk3MzaowBTwNbLuqOWSdERMjVz3JpWFKsuW5vKKjkTFZrjZ8EQwxeo4DWJBgAAAAEAAAABAAAAAQAAAAC4bWW88wMdhel4aAj+bff62qNlnMOZnhfTP6ECvP/qdAAAAAA=
+\.
+
+
+--
+-- Data for Name: trustlines; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY trustlines (accountid, assettype, issuer, assetcode, tlimit, balance, flags, lastmodified) FROM stdin;
+GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU	1	GC23QF2HUE52AMXUFUH3AYJAXXGXXV2VHXYYR6EYXETPKDXZSAW67XO4	USD	9223372036854775807	99900000000000	1	5
+\.
+
+
+--
+-- Data for Name: txfeehistory; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY txfeehistory (txid, ledgerseq, txindex, txchanges) FROM stdin;
+666656a6eade2082c5780571267d9e4453eee5781ca9a58aa319eb0fe83455fd	2	1	AAAAAgAAAAMAAAABAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+0ee11ddb4817a6165f062c28273bf521d9bfedca4ea304f7bded2cb8ed422b7e	2	2	AAAAAQAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/84AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+bd486dbdd02d460817671c4a5a7e9d6e865ca29cb41e62d7aaf70a2fee5b36de	3	1	AAAAAgAAAAMAAAACAAAAAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAA7msoAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAA7msmcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+267d3bd55a6902624d03f3895bc91bf89cb0379b75d39e5b97dc3d448a6ee5cb	4	1	AAAAAgAAAAMAAAACAAAAAAAAAAC1uBdHoTugMvQtD7BhIL3Ne9dVPfGI+Ji5JvUO+ZAt7wAAAAA7msoAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAAEAAAAAAAAAAC1uBdHoTugMvQtD7BhIL3Ne9dVPfGI+Ji5JvUO+ZAt7wAAAAA7msmcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+23071d02983ad8b70733b8ee52a19745a366d71c1f7455199773e7683ddaa035	5	1	AAAAAgAAAAMAAAADAAAAAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAA7msmcAAAAAgAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAAFAAAAAAAAAACuo3ot45qCPExpQ/3oHN+z17Ryis1lfMFYmQWgruS+TAAAAAA7msk4AAAAAgAAAAIAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+\.
+
+
+--
+-- Data for Name: txhistory; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) FROM stdin;
+666656a6eade2082c5780571267d9e4453eee5781ca9a58aa319eb0fe83455fd	2	1	AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAtbgXR6E7oDL0LQ+wYSC9zXvXVT3xiPiYuSb1DvmQLe8AAAAAO5rKAAAAAAAAAAABVvwF9wAAAEBdDXe23U4e9C2SxpBLZRx1rJzSFLJ0xDD0uKGpmqbflDT+XXIq6UiDBzmFxt+GO+XqFoQPdrXT7p1oLZIHqTMP	ZmZWpureIILFeAVxJn2eRFPu5XgcqaWKoxnrD+g0Vf0AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==	AAAAAAAAAAEAAAACAAAAAAAAAAIAAAAAAAAAALW4F0ehO6Ay9C0PsGEgvc1711U98Yj4mLkm9Q75kC3vAAAAADuaygAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAIAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3DeC2s2vJNTgAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA
+0ee11ddb4817a6165f062c28273bf521d9bfedca4ea304f7bded2cb8ed422b7e	2	2	AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAACAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAAAO5rKAAAAAAAAAAABVvwF9wAAAEAZCSSFbUKIiIThB3BIHf1u5g0vDSZQ0CD4fBA+pPqUQ/9dwSOSL+NGMZZvl2eJW02eOREjO4QVR4cIcmRmBdYN	DuEd20gXphZfBiwoJzv1Idm/7cpOowT3ve0suO1CK34AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==	AAAAAAAAAAEAAAACAAAAAAAAAAIAAAAAAAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAADuaygAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAIAAAAAAAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3DeC2szAuazgAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA
+bd486dbdd02d460817671c4a5a7e9d6e865ca29cb41e62d7aaf70a2fee5b36de	3	1	AAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABVVNEAAAAAAC1uBdHoTugMvQtD7BhIL3Ne9dVPfGI+Ji5JvUO+ZAt73//////////AAAAAAAAAAGu5L5MAAAAQB9kmKW2q3v7Qfy8PMekEb1TTI5ixqkI0BogXrOt7gO162Qbkh2dSTUfeDovc0PAafhDXxthVAlsLujlBmyjBAY=	vUhtvdAtRggXZxxKWn6dboZcopy0HmLXqvcKL+5bNt4AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAYAAAAAAAAAAA==	AAAAAAAAAAEAAAACAAAAAAAAAAMAAAABAAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAAVVTRAAAAAAAtbgXR6E7oDL0LQ+wYSC9zXvXVT3xiPiYuSb1DvmQLe8AAAAAAAAAAH//////////AAAAAQAAAAAAAAAAAAAAAQAAAAMAAAAAAAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAADuayZwAAAACAAAAAQAAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA
+267d3bd55a6902624d03f3895bc91bf89cb0379b75d39e5b97dc3d448a6ee5cb	4	1	AAAAALW4F0ehO6Ay9C0PsGEgvc1711U98Yj4mLkm9Q75kC3vAAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAArqN6LeOagjxMaUP96Bzfs9e0corNZXzBWJkFoK7kvkwAAAABVVNEAAAAAAC1uBdHoTugMvQtD7BhIL3Ne9dVPfGI+Ji5JvUO+ZAt7wAAWvMQekAAAAAAAAAAAAH5kC3vAAAAQMvzjWcUe8CdwX/cl5px2TkYt672RXOFvJOTK5fK6SjBpPHGj5EIFxCRXdLAFy2K1nSkHSnIk9N2qwwQKwK1sww=	Jn071VppAmJNA/OJW8kb+JywN5t1055bl9w9RIpu5csAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAA==	AAAAAAAAAAEAAAACAAAAAwAAAAMAAAABAAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAAVVTRAAAAAAAtbgXR6E7oDL0LQ+wYSC9zXvXVT3xiPiYuSb1DvmQLe8AAAAAAAAAAH//////////AAAAAQAAAAAAAAAAAAAAAQAAAAQAAAABAAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAAVVTRAAAAAAAtbgXR6E7oDL0LQ+wYSC9zXvXVT3xiPiYuSb1DvmQLe8AAFrzEHpAAH//////////AAAAAQAAAAAAAAAA
+23071d02983ad8b70733b8ee52a19745a366d71c1f7455199773e7683ddaa035	5	1	AAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAZAAAAAIAAAACAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAtbgXR6E7oDL0LQ+wYSC9zXvXVT3xiPiYuSb1DvmQLe8AAAABVVNEAAAAAAC1uBdHoTugMvQtD7BhIL3Ne9dVPfGI+Ji5JvUO+ZAt7wAAABdIdugAAAAAAAAAAAGu5L5MAAAAQJ7fL6KMtjD6elUg6OEd0ovvhbmnZNzM2qMAU8DWy7qjlknRETI1c9yaVhSrLlubyio5ExWa42fBEMMXqOA1iQY=	IwcdApg62LcHM7juUqGXRaNm1xwfdFUZl3PnaD3aoDUAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAEAAAAAAAAAAA==	AAAAAAAAAAEAAAACAAAAAwAAAAQAAAABAAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAAVVTRAAAAAAAtbgXR6E7oDL0LQ+wYSC9zXvXVT3xiPiYuSb1DvmQLe8AAFrzEHpAAH//////////AAAAAQAAAAAAAAAAAAAAAQAAAAUAAAABAAAAAK6jei3jmoI8TGlD/egc37PXtHKKzWV8wViZBaCu5L5MAAAAAVVTRAAAAAAAtbgXR6E7oDL0LQ+wYSC9zXvXVT3xiPiYuSb1DvmQLe8AAFrbyANYAH//////////AAAAAQAAAAAAAAAA
+\.
+
+
+--
+-- Name: accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY accounts
+    ADD CONSTRAINT accounts_pkey PRIMARY KEY (accountid);
+
+
+--
+-- Name: ledgerheaders_ledgerseq_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY ledgerheaders
+    ADD CONSTRAINT ledgerheaders_ledgerseq_key UNIQUE (ledgerseq);
+
+
+--
+-- Name: ledgerheaders_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY ledgerheaders
+    ADD CONSTRAINT ledgerheaders_pkey PRIMARY KEY (ledgerhash);
+
+
+--
+-- Name: offers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY offers
+    ADD CONSTRAINT offers_pkey PRIMARY KEY (offerid);
+
+
+--
+-- Name: peers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY peers
+    ADD CONSTRAINT peers_pkey PRIMARY KEY (ip, port);
+
+
+--
+-- Name: publishqueue_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY publishqueue
+    ADD CONSTRAINT publishqueue_pkey PRIMARY KEY (ledger);
+
+
+--
+-- Name: pubsub_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY pubsub
+    ADD CONSTRAINT pubsub_pkey PRIMARY KEY (resid);
+
+
+--
+-- Name: scpquorums_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY scpquorums
+    ADD CONSTRAINT scpquorums_pkey PRIMARY KEY (qsethash);
+
+
+--
+-- Name: signers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY signers
+    ADD CONSTRAINT signers_pkey PRIMARY KEY (accountid, publickey);
+
+
+--
+-- Name: storestate_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY storestate
+    ADD CONSTRAINT storestate_pkey PRIMARY KEY (statename);
+
+
+--
+-- Name: trustlines_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY trustlines
+    ADD CONSTRAINT trustlines_pkey PRIMARY KEY (accountid, issuer, assetcode);
+
+
+--
+-- Name: txfeehistory_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY txfeehistory
+    ADD CONSTRAINT txfeehistory_pkey PRIMARY KEY (ledgerseq, txindex);
+
+
+--
+-- Name: txhistory_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY txhistory
+    ADD CONSTRAINT txhistory_pkey PRIMARY KEY (ledgerseq, txindex);
+
+
+--
+-- Name: accountbalances; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX accountbalances ON accounts USING btree (balance) WHERE (balance >= 1000000000);
+
+
+--
+-- Name: buyingissuerindex; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX buyingissuerindex ON offers USING btree (buyingissuer);
+
+
+--
+-- Name: histbyseq; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX histbyseq ON txhistory USING btree (ledgerseq);
+
+
+--
+-- Name: histfeebyseq; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX histfeebyseq ON txfeehistory USING btree (ledgerseq);
+
+
+--
+-- Name: ledgersbyseq; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX ledgersbyseq ON ledgerheaders USING btree (ledgerseq);
+
+
+--
+-- Name: priceindex; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX priceindex ON offers USING btree (price);
+
+
+--
+-- Name: scpenvsbyseq; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX scpenvsbyseq ON scphistory USING btree (ledgerseq);
+
+
+--
+-- Name: sellingissuerindex; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX sellingissuerindex ON offers USING btree (sellingissuer);
+
+
+--
+-- Name: signersaccount; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX signersaccount ON signers USING btree (accountid);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/spec/fixtures/scenarios/send_to_issuer.rb
+++ b/spec/fixtures/scenarios/send_to_issuer.rb
@@ -1,0 +1,22 @@
+require 'factory_girl'
+FactoryGirl.find_definitions
+
+use_manual_close
+
+account :usd_gateway, FactoryGirl.create(:usd_gateway_key_pair)
+account :scott,  FactoryGirl.create(:scott_key_pair)
+
+create_account :usd_gateway,  :master, 100
+create_account :scott,  :master, 100
+
+close_ledger
+
+trust :scott,  :usd_gateway, "USD"
+
+close_ledger
+
+payment :usd_gateway, :scott, ["USD", :usd_gateway, 10_000_000]
+
+close_ledger
+
+payment :scott, :usd_gateway, ["USD", :usd_gateway, 10_000]


### PR DESCRIPTION
This PR fixes a situation in which an asset issuer was not properly
included in the participants for a transaction when credits issued by
it were sent back.